### PR TITLE
Add new Factory building

### DIFF
--- a/src/core/StatsSchemas.ts
+++ b/src/core/StatsSchemas.ts
@@ -37,6 +37,7 @@ export const OtherUnitSchema = z.union([
   z.literal("wshp"),
   z.literal("silo"),
   z.literal("saml"),
+  z.literal("fact"),
 ]);
 export type OtherUnit = z.infer<typeof OtherUnitSchema>;
 export type OtherUnitType =
@@ -45,7 +46,8 @@ export type OtherUnitType =
   | UnitType.MissileSilo
   | UnitType.Port
   | UnitType.SAMLauncher
-  | UnitType.Warship;
+  | UnitType.Warship
+  | UnitType.Factory;
 
 export const unitTypeToOtherUnit = {
   [UnitType.City]: "city",
@@ -54,6 +56,7 @@ export const unitTypeToOtherUnit = {
   [UnitType.Port]: "port",
   [UnitType.SAMLauncher]: "saml",
   [UnitType.Warship]: "wshp",
+  [UnitType.Factory]: "fact",
 } as const satisfies Record<OtherUnitType, OtherUnit>;
 
 // Attacks

--- a/src/core/configuration/DefaultConfig.ts
+++ b/src/core/configuration/DefaultConfig.ts
@@ -421,6 +421,15 @@ export class DefaultConfig implements Config {
           territoryBound: true,
           constructionDuration: this.instantBuild() ? 0 : 2 * 10,
         };
+      case UnitType.Factory:
+        return {
+          cost: (p: Player) =>
+            p.type() === PlayerType.Human && this.infiniteGold()
+              ? 0n
+              : 1_000_000n,
+          territoryBound: true,
+          constructionDuration: this.instantBuild() ? 0 : 2 * 10,
+        };
       case UnitType.Construction:
         return {
           cost: () => 0n,

--- a/src/core/execution/ConstructionExecution.ts
+++ b/src/core/execution/ConstructionExecution.ts
@@ -18,6 +18,7 @@ import { NukeExecution } from "./NukeExecution";
 import { PortExecution } from "./PortExecution";
 import { SAMLauncherExecution } from "./SAMLauncherExecution";
 import { WarshipExecution } from "./WarshipExecution";
+import { FactoryExecution } from "./FactoryExecution";
 
 export class ConstructionExecution implements Execution {
   private player: Player;
@@ -123,6 +124,9 @@ export class ConstructionExecution implements Execution {
         break;
       case UnitType.City:
         this.mg.addExecution(new CityExecution(player.id(), this.tile));
+        break;
+      case UnitType.Factory:
+        this.mg.addExecution(new FactoryExecution(player.id(), this.tile));
         break;
       default:
         throw Error(`unit type ${this.constructionType} not supported`);

--- a/src/core/execution/FactoryExecution.ts
+++ b/src/core/execution/FactoryExecution.ts
@@ -1,0 +1,63 @@
+import { consolex } from "../Consolex";
+import {
+  Execution,
+  Game,
+  Gold,
+  Player,
+  PlayerID,
+  Unit,
+  UnitType,
+} from "../game/Game";
+import { TileRef } from "../game/GameMap";
+
+export class FactoryExecution implements Execution {
+  private player: Player;
+  private mg: Game;
+  private factory: Unit | null = null;
+  private active = true;
+
+  private goldPerTick: Gold = 100n; // 1000 gold per second at 10 ticks/sec
+
+  constructor(private ownerId: PlayerID, private tile: TileRef) {}
+
+  init(mg: Game, ticks: number): void {
+    this.mg = mg;
+    if (!mg.hasPlayer(this.ownerId)) {
+      console.warn(`FactoryExecution: player ${this.ownerId} not found`);
+      this.active = false;
+      return;
+    }
+    this.player = mg.player(this.ownerId);
+  }
+
+  tick(ticks: number): void {
+    if (this.factory === null) {
+      const spawnTile = this.player.canBuild(UnitType.Factory, this.tile);
+      if (spawnTile === false) {
+        consolex.warn("cannot build factory");
+        this.active = false;
+        return;
+      }
+      this.factory = this.player.buildUnit(UnitType.Factory, spawnTile, {});
+    }
+    if (!this.factory.isActive()) {
+      this.active = false;
+      return;
+    }
+
+    if (this.player !== this.factory.owner()) {
+      this.player = this.factory.owner();
+    }
+
+    this.player.addGold(this.goldPerTick);
+    this.mg.stats().goldWork(this.player, this.goldPerTick);
+  }
+
+  isActive(): boolean {
+    return this.active;
+  }
+
+  activeDuringSpawnPhase(): boolean {
+    return false;
+  }
+}

--- a/src/core/game/Game.ts
+++ b/src/core/game/Game.ts
@@ -145,6 +145,7 @@ export enum UnitType {
   DefensePost = "Defense Post",
   SAMLauncher = "SAM Launcher",
   City = "City",
+  Factory = "Factory",
   MIRV = "MIRV",
   MIRVWarhead = "MIRV Warhead",
   Construction = "Construction",
@@ -192,6 +193,8 @@ export interface UnitParamsMap {
   [UnitType.SAMLauncher]: {};
 
   [UnitType.City]: {};
+
+  [UnitType.Factory]: {};
 
   [UnitType.MIRV]: {};
 

--- a/src/core/game/PlayerImpl.ts
+++ b/src/core/game/PlayerImpl.ts
@@ -793,6 +793,7 @@ export class PlayerImpl implements Player {
       case UnitType.DefensePost:
       case UnitType.SAMLauncher:
       case UnitType.City:
+      case UnitType.Factory:
       case UnitType.Construction:
         return this.landBasedStructureSpawn(targetTile, validTiles);
       default:

--- a/src/core/game/UnitImpl.ts
+++ b/src/core/game/UnitImpl.ts
@@ -57,6 +57,7 @@ export class UnitImpl implements Unit {
       case UnitType.DefensePost:
       case UnitType.SAMLauncher:
       case UnitType.City:
+      case UnitType.Factory:
         this.mg.stats().unitBuild(_owner, this._type);
     }
   }
@@ -158,6 +159,7 @@ export class UnitImpl implements Unit {
       case UnitType.DefensePost:
       case UnitType.SAMLauncher:
       case UnitType.City:
+      case UnitType.Factory:
         this.mg.stats().unitCapture(newOwner, this._type);
         this.mg.stats().unitLose(this._owner, this._type);
     }
@@ -220,6 +222,7 @@ export class UnitImpl implements Unit {
         case UnitType.Port:
         case UnitType.SAMLauncher:
         case UnitType.Warship:
+        case UnitType.Factory:
           this.mg.stats().unitDestroy(destroyer, this._type);
           this.mg.stats().unitLose(this.owner(), this._type);
           break;


### PR DESCRIPTION
## Summary
- introduce new `Factory` structure that produces gold
- track factories in stats
- allow players to construct factories
- config default info for factories

## Testing
- `npx prettier` *(fails: Cannot find package 'prettier-plugin-organize-imports')*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f40ed89dc832eb264808c6c97e283