### PR TITLE
Fix sprite loading race

### DIFF
--- a/src/client/graphics/layers/UnitLayer.ts
+++ b/src/client/graphics/layers/UnitLayer.ts
@@ -76,7 +76,7 @@ export class UnitLayer implements Layer {
     this.eventBus.on(UnitSelectionEvent, (e) => this.onUnitSelectionChange(e));
     this.redraw();
 
-    loadAllSprites();
+    loadAllSprites().then(() => this.redraw());
   }
 
   /**
@@ -502,6 +502,10 @@ export class UnitLayer implements Layer {
   }
 
   drawSprite(unit: UnitView, customTerritoryColor?: Colord) {
+    if (!isSpriteReady(unit.type())) {
+      return; // sprite still loading
+    }
+
     const x = this.game.x(unit.tile());
     const y = this.game.y(unit.tile());
 


### PR DESCRIPTION
## Summary
- ensure sprites are loaded before drawing
- trigger redraw when sprites finish loading

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684091d8dd8c832e963d008874eab68c