### PR TITLE
Fix sprite loading race

### DIFF
--- a/resources/sprites/tradeplane.svg
+++ b/resources/sprites/tradeplane.svg
@@ -1,3 +1,4 @@
-<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-  <path fill="#b4b4b4" d="M21 16v-2L13 9V3.5a1.5 1.5 0 0 0-3 0V9L3 14v2l7-2v5l-2 1v2l3-1 3 1v-2l-2-1v-5l7 2z"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+  <path fill="#b4b4b4" stroke="#464646" stroke-width="0.5" d="M2 15v-2l9-5V3.5a1.5 1.5 0 0 1 3 0V8l9 5v2l-9-2v4l3 1v2l-3-1-3 1v-2l3-1v-4z"/>
+  <path fill="#828282" d="M11 10h2v3h-2z"/>
 </svg>

--- a/src/client/graphics/layers/UnitLayer.ts
+++ b/src/client/graphics/layers/UnitLayer.ts
@@ -76,7 +76,7 @@ export class UnitLayer implements Layer {
     this.eventBus.on(UnitSelectionEvent, (e) => this.onUnitSelectionChange(e));
     this.redraw();
 
-    loadAllSprites();
+    loadAllSprites().then(() => this.redraw());
   }
 
   /**
@@ -502,6 +502,10 @@ export class UnitLayer implements Layer {
   }
 
   drawSprite(unit: UnitView, customTerritoryColor?: Colord) {
+    if (!isSpriteReady(unit.type())) {
+      return; // sprite still loading
+    }
+
     const x = this.game.x(unit.tile());
     const y = this.game.y(unit.tile());
 


### PR DESCRIPTION
## Summary
- ensure sprites are loaded before drawing
- trigger redraw when sprites finish loading
- add clearer trade plane sprite

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684091d8dd8c832e963d008874eab68c