### PR TITLE
Add airport building and air trading feature

### DIFF
--- a/resources/images/AirportIconWhite.svg
+++ b/resources/images/AirportIconWhite.svg
@@ -1,0 +1,3 @@
+<svg viewBox="0 0 24 24" fill="white" xmlns="http://www.w3.org/2000/svg">
+  <path d="M21 16v-2L13 9V3.5a1.5 1.5 0 0 0-3 0V9L3 14v2l7-2v5l-2 1v2l3-1 3 1v-2l-2-1v-5l7 2z"/>
+</svg>

--- a/resources/images/AirportUnitIcon.svg
+++ b/resources/images/AirportUnitIcon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="9" height="9" style="shape-rendering:geometricPrecision; text-rendering:geometricPrecision; image-rendering:optimizeQuality; fill-rule:evenodd; clip-rule:evenodd">
+  <path fill="#000" d="M1 7h7v1H1zM3 3h3v4H3zM4 0h1v3H4z"/>
+</svg>

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -92,6 +92,8 @@
     "build_defense_desc": "Increases defenses around nearby borders, which show a checkered pattern. Attacks from enemies are slower and have more casualties.",
     "build_port": "Port",
     "build_port_desc": "Can only be built near water. Allows building Warships. Automatically sends trade ships between ports of your country and other countries (except when trade is stopped), giving gold to both sides. Trade stops automatically when you attack or are attacked by a player. It resumes after 5 minutes or if you become allies. You can manually toggle trading with \"Stop trading\" or \"Start trading\".",
+    "build_airport": "Airport",
+    "build_airport_desc": "Allows air trade between countries.",
     "build_warship": "Warship",
     "build_warship_desc": "Patrols in an area, capturing enemy trade ships and destroying their Boats (transport ships) and Warships. Spawns from the nearest Port and patrols the area you first clicked to build it. You can control Warships by attack-clicking on them (see action Attack under Hotkeys) and then attack-clicking the new area you want them to move to.",
     "build_silo": "Missile Silo",
@@ -228,7 +230,8 @@
     "atom_bomb": "Atom Bomb",
     "hydrogen_bomb": "Hydrogen Bomb",
     "mirv": "MIRV",
-    "factory": "Factory"
+    "factory": "Factory",
+    "airport": "Airport"
   },
   "user_setting": {
     "title": "User Settings",
@@ -356,6 +359,7 @@
       "sam_launcher": "Defends against incoming nukes",
       "warship": "Captures trade ships, destroys ships and boats",
       "port": "Sends trade ships to generate gold",
+      "airport": "Enables air trade with other countries",
       "defense_post": "Increase defenses of nearby borders",
       "city": "Increase max population",
       "factory": "Produces gold over time"

--- a/resources/sprites/tradeplane.svg
+++ b/resources/sprites/tradeplane.svg
@@ -1,0 +1,3 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+  <path fill="#b4b4b4" d="M21 16v-2L13 9V3.5a1.5 1.5 0 0 0-3 0V9L3 14v2l7-2v5l-2 1v2l3-1 3 1v-2l-2-1v-5l7 2z"/>
+</svg>

--- a/src/client/graphics/SpriteLoader.ts
+++ b/src/client/graphics/SpriteLoader.ts
@@ -3,6 +3,7 @@ import atomBombSprite from "../../../resources/sprites/atombomb.png";
 import hydrogenBombSprite from "../../../resources/sprites/hydrogenbomb.png";
 import mirvSprite from "../../../resources/sprites/mirv2.png";
 import samMissileSprite from "../../../resources/sprites/samMissile.png";
+import tradePlaneSprite from "../../../resources/sprites/tradeplane.svg";
 import tradeShipSprite from "../../../resources/sprites/tradeship.png";
 import transportShipSprite from "../../../resources/sprites/transportship.png";
 import warshipSprite from "../../../resources/sprites/warship.png";
@@ -17,6 +18,7 @@ const SPRITE_CONFIG: Partial<Record<UnitType, string>> = {
   [UnitType.AtomBomb]: atomBombSprite,
   [UnitType.HydrogenBomb]: hydrogenBombSprite,
   [UnitType.TradeShip]: tradeShipSprite,
+  [UnitType.TradePlane]: tradePlaneSprite,
   [UnitType.MIRV]: mirvSprite,
 };
 

--- a/src/client/graphics/layers/BuildMenu.ts
+++ b/src/client/graphics/layers/BuildMenu.ts
@@ -1,5 +1,6 @@
 import { LitElement, css, html } from "lit";
 import { customElement, state } from "lit/decorators.js";
+import airportIcon from "../../../../resources/images/AirportIconWhite.svg";
 import warshipIcon from "../../../../resources/images/BattleshipIconWhite.svg";
 import cityIcon from "../../../../resources/images/CityIconWhite.svg";
 import factoryIcon from "../../../../resources/images/FactoryIconWhite.svg";
@@ -63,6 +64,13 @@ const buildTable: BuildItemDisplay[][] = [
       icon: portIcon,
       description: "build_menu.desc.port",
       key: "unit_type.port",
+      countable: true,
+    },
+    {
+      unitType: UnitType.Airport,
+      icon: airportIcon,
+      description: "build_menu.desc.airport",
+      key: "unit_type.airport",
       countable: true,
     },
     {

--- a/src/client/graphics/layers/StructureLayer.ts
+++ b/src/client/graphics/layers/StructureLayer.ts
@@ -6,6 +6,7 @@ import { TransformHandler } from "../TransformHandler";
 import { Layer } from "./Layer";
 import { UnitInfoModal } from "./UnitInfoModal";
 
+import airportBuildingIcon from "../../../../resources/images/AirportUnitIcon.svg";
 import cityIcon from "../../../../resources/images/buildings/cityAlt1.png";
 import shieldIcon from "../../../../resources/images/buildings/fortAlt2.png";
 import anchorIcon from "../../../../resources/images/buildings/port1.png";
@@ -86,6 +87,12 @@ export class StructureLayer implements Layer {
     },
     [UnitType.Factory]: {
       icon: factoryIcon,
+      borderRadius: 8.525,
+      territoryRadius: 6.525,
+      borderType: UnitBorderType.Round,
+    },
+    [UnitType.Airport]: {
+      icon: airportBuildingIcon,
       borderRadius: 8.525,
       territoryRadius: 6.525,
       borderType: UnitBorderType.Round,

--- a/src/client/graphics/layers/UnitLayer.ts
+++ b/src/client/graphics/layers/UnitLayer.ts
@@ -279,6 +279,9 @@ export class UnitLayer implements Layer {
       case UnitType.TradeShip:
         this.handleTradeShipEvent(unit);
         break;
+      case UnitType.TradePlane:
+        this.handleTradePlaneEvent(unit);
+        break;
       case UnitType.MIRVWarhead:
         this.handleMIRVWarhead(unit);
         break;
@@ -434,6 +437,10 @@ export class UnitLayer implements Layer {
   }
 
   private handleTradeShipEvent(unit: UnitView) {
+    this.drawSprite(unit);
+  }
+
+  private handleTradePlaneEvent(unit: UnitView) {
     this.drawSprite(unit);
   }
 

--- a/src/client/styles.css
+++ b/src/client/styles.css
@@ -369,6 +369,11 @@ label.option-card:hover {
   mask: url("../../resources/images/PortIcon.svg") no-repeat center / cover;
 }
 
+#helpModal .airport-icon {
+  mask: url("../../resources/images/AirportIconWhite.svg") no-repeat center /
+    cover;
+}
+
 #helpModal .warship-icon {
   mask: url("../../resources/images/BattleshipIconWhite.svg") no-repeat center /
     cover;

--- a/src/core/StatsSchemas.ts
+++ b/src/core/StatsSchemas.ts
@@ -38,6 +38,7 @@ export const OtherUnitSchema = z.union([
   z.literal("silo"),
   z.literal("saml"),
   z.literal("fact"),
+  z.literal("airp"),
 ]);
 export type OtherUnit = z.infer<typeof OtherUnitSchema>;
 export type OtherUnitType =
@@ -47,7 +48,8 @@ export type OtherUnitType =
   | UnitType.Port
   | UnitType.SAMLauncher
   | UnitType.Warship
-  | UnitType.Factory;
+  | UnitType.Factory
+  | UnitType.Airport;
 
 export const unitTypeToOtherUnit = {
   [UnitType.City]: "city",
@@ -57,6 +59,7 @@ export const unitTypeToOtherUnit = {
   [UnitType.SAMLauncher]: "saml",
   [UnitType.Warship]: "wshp",
   [UnitType.Factory]: "fact",
+  [UnitType.Airport]: "airp",
 } as const satisfies Record<OtherUnitType, OtherUnit>;
 
 // Attacks

--- a/src/core/configuration/DefaultConfig.ts
+++ b/src/core/configuration/DefaultConfig.ts
@@ -363,6 +363,11 @@ export class DefaultConfig implements Config {
           cost: () => 0n,
           territoryBound: false,
         };
+      case UnitType.TradePlane:
+        return {
+          cost: () => 0n,
+          territoryBound: false,
+        };
       case UnitType.MissileSilo:
         return {
           cost: (p: Player) =>
@@ -429,6 +434,15 @@ export class DefaultConfig implements Config {
               : 3_000_000n,
           territoryBound: true,
           constructionDuration: this.instantBuild() ? 0 : 2 * 10,
+        };
+      case UnitType.Airport:
+        return {
+          cost: (p: Player) =>
+            p.type() === PlayerType.Human && this.infiniteGold()
+              ? 0n
+              : 10_000_000n,
+          territoryBound: true,
+          constructionDuration: this.instantBuild() ? 0 : 10 * 10,
         };
       case UnitType.Construction:
         return {

--- a/src/core/execution/AirportExecution.ts
+++ b/src/core/execution/AirportExecution.ts
@@ -1,0 +1,92 @@
+import { consolex } from "../Consolex";
+import {
+  Execution,
+  Game,
+  Player,
+  PlayerID,
+  Unit,
+  UnitType,
+} from "../game/Game";
+import { TileRef } from "../game/GameMap";
+import { PseudoRandom } from "../PseudoRandom";
+import { TradePlaneExecution } from "./TradePlaneExecution";
+
+export class AirportExecution implements Execution {
+  private active = true;
+  private mg: Game | null = null;
+  private airport: Unit | null = null;
+  private random: PseudoRandom | null = null;
+  private checkOffset: number | null = null;
+
+  constructor(
+    private _owner: PlayerID,
+    private tile: TileRef,
+  ) {}
+
+  init(mg: Game, ticks: number): void {
+    if (!mg.hasPlayer(this._owner)) {
+      console.warn(`AirportExecution: player ${this._owner} not found`);
+      this.active = false;
+      return;
+    }
+    this.mg = mg;
+    this.random = new PseudoRandom(mg.ticks());
+    this.checkOffset = mg.ticks() % 10;
+  }
+
+  tick(ticks: number): void {
+    if (this.mg === null || this.random === null || this.checkOffset === null) {
+      throw new Error("Not initialized");
+    }
+    if (this.airport === null) {
+      const player = this.mg.player(this._owner);
+      const spawn = player.canBuild(UnitType.Airport, this.tile);
+      if (spawn === false) {
+        consolex.warn(`player ${player} cannot build airport at ${this.tile}`);
+        this.active = false;
+        return;
+      }
+      this.airport = player.buildUnit(UnitType.Airport, spawn, {});
+    }
+
+    if (!this.airport.isActive()) {
+      this.active = false;
+      return;
+    }
+
+    if (this._owner !== this.airport.owner().id()) {
+      this._owner = this.airport.owner().id();
+    }
+
+    if ((this.mg.ticks() + this.checkOffset) % 10 !== 0) {
+      return;
+    }
+
+    const total = this.mg.units(UnitType.Airport).length;
+    if (!this.random.chance(this.mg.config().tradeShipSpawnRate(total))) {
+      return;
+    }
+
+    const airports = this.player().tradingAirports(this.airport);
+    if (airports.length === 0) {
+      return;
+    }
+    const airport = this.random.randElement(airports);
+    this.mg.addExecution(
+      new TradePlaneExecution(this.player().id(), this.airport, airport),
+    );
+  }
+
+  isActive(): boolean {
+    return this.active;
+  }
+
+  activeDuringSpawnPhase(): boolean {
+    return false;
+  }
+
+  player(): Player {
+    if (this.airport === null) throw new Error("Not initialized");
+    return this.airport.owner();
+  }
+}

--- a/src/core/execution/ConstructionExecution.ts
+++ b/src/core/execution/ConstructionExecution.ts
@@ -10,15 +10,16 @@ import {
   UnitType,
 } from "../game/Game";
 import { TileRef } from "../game/GameMap";
+import { AirportExecution } from "./AirportExecution";
 import { CityExecution } from "./CityExecution";
 import { DefensePostExecution } from "./DefensePostExecution";
+import { FactoryExecution } from "./FactoryExecution";
 import { MirvExecution } from "./MIRVExecution";
 import { MissileSiloExecution } from "./MissileSiloExecution";
 import { NukeExecution } from "./NukeExecution";
 import { PortExecution } from "./PortExecution";
 import { SAMLauncherExecution } from "./SAMLauncherExecution";
 import { WarshipExecution } from "./WarshipExecution";
-import { FactoryExecution } from "./FactoryExecution";
 
 export class ConstructionExecution implements Execution {
   private player: Player;
@@ -112,6 +113,9 @@ export class ConstructionExecution implements Execution {
         break;
       case UnitType.Port:
         this.mg.addExecution(new PortExecution(player.id(), this.tile));
+        break;
+      case UnitType.Airport:
+        this.mg.addExecution(new AirportExecution(player.id(), this.tile));
         break;
       case UnitType.MissileSilo:
         this.mg.addExecution(new MissileSiloExecution(player.id(), this.tile));

--- a/src/core/execution/TradePlaneExecution.ts
+++ b/src/core/execution/TradePlaneExecution.ts
@@ -1,0 +1,100 @@
+import { renderNumber } from "../../client/Utils";
+import { consolex } from "../Consolex";
+import {
+  Execution,
+  Game,
+  MessageType,
+  Player,
+  PlayerID,
+  Unit,
+  UnitType,
+} from "../game/Game";
+import { TileRef } from "../game/GameMap";
+import { AirPathFinder } from "../pathfinding/PathFinding";
+import { PseudoRandom } from "../PseudoRandom";
+
+export class TradePlaneExecution implements Execution {
+  private active = true;
+  private mg: Game;
+  private origOwner: Player;
+  private tradePlane: Unit | undefined;
+  private pathFinder: AirPathFinder;
+
+  constructor(
+    private _owner: PlayerID,
+    private srcAirport: Unit,
+    private _dstAirport: Unit,
+  ) {}
+
+  init(mg: Game, ticks: number): void {
+    this.mg = mg;
+    this.origOwner = mg.player(this._owner);
+    this.pathFinder = new AirPathFinder(mg, new PseudoRandom(mg.ticks()));
+  }
+
+  tick(ticks: number): void {
+    if (this.tradePlane === undefined) {
+      const spawn = this.origOwner.canBuild(
+        UnitType.TradePlane,
+        this.srcAirport.tile(),
+      );
+      if (spawn === false) {
+        consolex.warn(`cannot build trade plane`);
+        this.active = false;
+        return;
+      }
+      this.tradePlane = this.origOwner.buildUnit(UnitType.TradePlane, spawn, {
+        targetUnit: this._dstAirport,
+      });
+    }
+
+    if (!this.tradePlane.isActive()) {
+      this.active = false;
+      return;
+    }
+
+    const result = this.pathFinder.nextTile(
+      this.tradePlane.tile(),
+      this._dstAirport.tile(),
+    );
+    if (result === true) {
+      this.complete();
+    } else {
+      this.tradePlane.move(result);
+    }
+  }
+
+  private complete() {
+    this.active = false;
+    this.tradePlane!.delete(false);
+    const gold = this.mg
+      .config()
+      .tradeShipGold(
+        this.mg.manhattanDist(this.srcAirport.tile(), this._dstAirport.tile()),
+      );
+    this.srcAirport.owner().addGold(gold);
+    this._dstAirport.owner().addGold(gold);
+    this.mg.displayMessage(
+      `Received ${renderNumber(gold)} gold from air trade with ${this.srcAirport.owner().displayName()}`,
+      MessageType.SUCCESS,
+      this._dstAirport.owner().id(),
+    );
+    this.mg.displayMessage(
+      `Received ${renderNumber(gold)} gold from air trade with ${this._dstAirport.owner().displayName()}`,
+      MessageType.SUCCESS,
+      this.srcAirport.owner().id(),
+    );
+  }
+
+  isActive(): boolean {
+    return this.active;
+  }
+
+  activeDuringSpawnPhase(): boolean {
+    return false;
+  }
+
+  dstAirport(): TileRef {
+    return this._dstAirport.tile();
+  }
+}

--- a/src/core/game/Game.ts
+++ b/src/core/game/Game.ts
@@ -141,11 +141,13 @@ export enum UnitType {
   AtomBomb = "Atom Bomb",
   HydrogenBomb = "Hydrogen Bomb",
   TradeShip = "Trade Ship",
+  TradePlane = "Trade Plane",
   MissileSilo = "Missile Silo",
   DefensePost = "Defense Post",
   SAMLauncher = "SAM Launcher",
   City = "City",
   Factory = "Factory",
+  Airport = "Airport",
   MIRV = "MIRV",
   MIRVWarhead = "MIRV Warhead",
   Construction = "Construction",
@@ -184,6 +186,10 @@ export interface UnitParamsMap {
     lastSetSafeFromPirates?: number;
   };
 
+  [UnitType.TradePlane]: {
+    targetUnit: Unit;
+  };
+
   [UnitType.MissileSilo]: {
     cooldownDuration?: number;
   };
@@ -195,6 +201,8 @@ export interface UnitParamsMap {
   [UnitType.City]: {};
 
   [UnitType.Factory]: {};
+
+  [UnitType.Airport]: {};
 
   [UnitType.MIRV]: {};
 
@@ -539,6 +547,7 @@ export interface Player {
   toUpdate(): PlayerUpdate;
   playerProfile(): PlayerProfile;
   tradingPorts(port: Unit): Unit[];
+  tradingAirports(airport: Unit): Unit[];
   // WARNING: this operation is expensive.
   bestTransportShipSpawn(tile: TileRef): TileRef | false;
 }

--- a/src/core/game/UnitImpl.ts
+++ b/src/core/game/UnitImpl.ts
@@ -58,6 +58,7 @@ export class UnitImpl implements Unit {
       case UnitType.SAMLauncher:
       case UnitType.City:
       case UnitType.Factory:
+      case UnitType.Airport:
         this.mg.stats().unitBuild(_owner, this._type);
     }
   }
@@ -160,6 +161,7 @@ export class UnitImpl implements Unit {
       case UnitType.SAMLauncher:
       case UnitType.City:
       case UnitType.Factory:
+      case UnitType.Airport:
         this.mg.stats().unitCapture(newOwner, this._type);
         this.mg.stats().unitLose(this._owner, this._type);
     }
@@ -223,6 +225,7 @@ export class UnitImpl implements Unit {
         case UnitType.SAMLauncher:
         case UnitType.Warship:
         case UnitType.Factory:
+        case UnitType.Airport:
           this.mg.stats().unitDestroy(destroyer, this._type);
           this.mg.stats().unitLose(this.owner(), this._type);
           break;

--- a/tests/Stats.test.ts
+++ b/tests/Stats.test.ts
@@ -190,6 +190,13 @@ describe("Stats", () => {
     });
   });
 
+  test("unitBuild airport", () => {
+    stats.unitBuild(player1, UnitType.Airport);
+    expect(stats.stats()).toStrictEqual({
+      client1: { units: { airp: [1n] } },
+    });
+  });
+
   test("unitCapture", () => {
     stats.unitCapture(player1, UnitType.DefensePost);
     expect(stats.stats()).toStrictEqual({


### PR DESCRIPTION
## Summary
- introduce new `Airport` and `TradePlane` units
- enable airports to spawn trade planes for international trade
- allow players to build airports from the build menu
- show airport structures with new icons
- localize new airport strings
- add stats coverage and tests
- add separate map icon for airports so it fits inside the structure circle

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68404b06b07c832e8eca7bfba8c90a2e