### PR TITLE
Fix airport construction icon not refreshing

### DIFF
--- a/src/client/graphics/layers/StructureLayer.ts
+++ b/src/client/graphics/layers/StructureLayer.ts
@@ -157,6 +157,20 @@ export class StructureLayer implements Layer {
       console.log(
         `icon data width height: ${iconData.width}, ${iconData.height}`,
       );
+      // Re-render units that rely on this icon once it's loaded
+      this.game.units().forEach((u) => {
+        const currentType = u.constructionType() ?? u.type();
+        let expectedKey: string = currentType;
+        if (
+          u.type() === UnitType.Construction &&
+          u.constructionType() === UnitType.Airport
+        ) {
+          expectedKey = "airportConstruction";
+        }
+        if (expectedKey === unitType) {
+          this.handleUnitRendering(u);
+        }
+      });
     };
   }
 


### PR DESCRIPTION
## Summary
- re-render units when construction icons load

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6840a4a7af18832ea955b34ad05aa911