### PR TITLE
Add plane bomb bomber option

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -106,6 +106,7 @@
     "build_atom_desc": "Small explosive bomb that destroys territory, buildings, ships and boats. Spawns from the nearest Missile Silo and lands in the area you first clicked to build it.",
     "build_hydrogen": "Hydrogen Bomb",
     "build_hydrogen_desc": "Large explosive bomb. Spawns from the nearest Missile Silo and lands in the area you first clicked to build it.",
+    "build_plane_bomb": "Requires a war plane. Drops a nuke from above that cannot be intercepted.",
     "build_mirv": "MIRV",
     "build_mirv_desc": "The most powerful bomb in the game. Splits up into smaller bombs that will cover a huge range of territory. Only damages the player that you first clicked on to build it. Spawns from the nearest Missile Silo and lands in the area you first clicked to build it.",
     "player_icons": "Player icons",
@@ -232,6 +233,7 @@
     "sam_launcher": "SAM Launcher",
     "atom_bomb": "Atom Bomb",
     "hydrogen_bomb": "Hydrogen Bomb",
+    "plane_bomb": "Plane Bomb",
     "mirv": "MIRV",
     "factory": "Factory",
     "airport": "Airport"
@@ -362,6 +364,7 @@
       "sam_launcher": "Defends against incoming nukes",
       "warship": "Captures trade ships, destroys ships and boats",
       "warplane": "Attacks enemy planes",
+      "plane_bomb": "Air dropped nuke",
       "port": "Sends trade ships to generate gold",
       "airport": "Enables air trade with other countries",
       "defense_post": "Increase defenses of nearby borders",

--- a/resources/lang/fr.json
+++ b/resources/lang/fr.json
@@ -96,6 +96,7 @@
     "build_atom_desc": "Petite bombe explosive qui détruit le territoire, les bâtiments, les navires et les bateaux. Apparaît depuis le Silo à missiles le plus proche et atterrit dans la zone cliquée.",
     "build_hydrogen": "Bombe à hydrogène",
     "build_hydrogen_desc": "Grande bombe explosive. Apparaît depuis le Silo à Missiles le plus proche et atterrit dans la zone cliquée.",
+    "build_plane_bomb": "Nécessite un avion de guerre. Lâche une bombe nucléaire inarrêtable.",
     "build_mirv": "MIRV",
     "build_mirv_desc": "La bombe la plus puissante du jeu. Se divise en plus petites bombes qui couvriront une vaste zone du territoire. Ne fait des dégâts qu'au joueur sur lequel vous avez cliqué pour la construire. Apparaît depuis le Silo à missiles le plus proche et atterrit dans la zone cliquée.",
     "player_icons": "Icônes des joueurs",
@@ -222,6 +223,7 @@
     "sam_launcher": "Lanceur de SAM",
     "atom_bomb": "Bombe atomique",
     "hydrogen_bomb": "Bombe à hydrogène",
+    "plane_bomb": "Bombe d'avion",
     "mirv": "MIRV",
     "factory": "Usine"
   },
@@ -351,6 +353,7 @@
       "sam_launcher": "Protège contre les bombes nucléaires",
       "warship": "Capture les navires commerciaux, détruit les navires de guerre et les bateaux",
       "warplane": "Attaque les avions ennemis",
+      "plane_bomb": "Bombe lâchée par avion",
       "port": "Envoie des navires commerciaux pour produire de l'or",
       "defense_post": "Augmente les défenses des frontières voisines",
       "city": "Augmente la population maximale",

--- a/src/client/graphics/SpriteLoader.ts
+++ b/src/client/graphics/SpriteLoader.ts
@@ -18,6 +18,7 @@ const SPRITE_CONFIG: Partial<Record<UnitType, string>> = {
   [UnitType.SAMMissile]: samMissileSprite,
   [UnitType.AtomBomb]: atomBombSprite,
   [UnitType.HydrogenBomb]: hydrogenBombSprite,
+  [UnitType.PlaneBomb]: atomBombSprite,
   [UnitType.TradeShip]: tradeShipSprite,
   [UnitType.TradePlane]: tradePlaneSprite,
   [UnitType.WarPlane]: warPlaneSprite,

--- a/src/client/graphics/layers/BuildMenu.ts
+++ b/src/client/graphics/layers/BuildMenu.ts
@@ -68,6 +68,13 @@ const buildTable: BuildItemDisplay[][] = [
       countable: true,
     },
     {
+      unitType: UnitType.PlaneBomb,
+      icon: atomBombIcon,
+      description: "build_menu.desc.plane_bomb",
+      key: "unit_type.plane_bomb",
+      countable: false,
+    },
+    {
       unitType: UnitType.Port,
       icon: portIcon,
       description: "build_menu.desc.port",

--- a/src/core/StatsSchemas.ts
+++ b/src/core/StatsSchemas.ts
@@ -4,6 +4,7 @@ import { UnitType } from "./game/Game";
 export const BombUnitSchema = z.union([
   z.literal("abomb"),
   z.literal("hbomb"),
+  z.literal("pbomb"),
   z.literal("mirv"),
   z.literal("mirvw"),
 ]);
@@ -11,12 +12,14 @@ export type BombUnit = z.infer<typeof BombUnitSchema>;
 export type NukeType =
   | UnitType.AtomBomb
   | UnitType.HydrogenBomb
+  | UnitType.PlaneBomb
   | UnitType.MIRV
   | UnitType.MIRVWarhead;
 
 export const unitTypeToBombUnit = {
   [UnitType.AtomBomb]: "abomb",
   [UnitType.HydrogenBomb]: "hbomb",
+  [UnitType.PlaneBomb]: "pbomb",
   [UnitType.MIRV]: "mirv",
   [UnitType.MIRVWarhead]: "mirvw",
 } as const satisfies Record<NukeType, BombUnit>;

--- a/src/core/configuration/DefaultConfig.ts
+++ b/src/core/configuration/DefaultConfig.ts
@@ -354,6 +354,14 @@ export class DefaultConfig implements Config {
               : 5_000_000n,
           territoryBound: false,
         };
+      case UnitType.PlaneBomb:
+        return {
+          cost: (p: Player) =>
+            p.type() === PlayerType.Human && this.infiniteGold()
+              ? 0n
+              : 750_000n,
+          territoryBound: false,
+        };
       case UnitType.MIRV:
         return {
           cost: (p: Player) =>
@@ -760,6 +768,8 @@ export class DefaultConfig implements Config {
         return { inner: 12, outer: 30 };
       case UnitType.HydrogenBomb:
         return { inner: 80, outer: 100 };
+      case UnitType.PlaneBomb:
+        return { inner: 12, outer: 30 };
     }
     throw new Error(`Unknown nuke type: ${unitType}`);
   }

--- a/src/core/execution/ConstructionExecution.ts
+++ b/src/core/execution/ConstructionExecution.ts
@@ -100,6 +100,7 @@ export class ConstructionExecution implements Execution {
     switch (this.constructionType) {
       case UnitType.AtomBomb:
       case UnitType.HydrogenBomb:
+      case UnitType.PlaneBomb:
         this.mg.addExecution(
           new NukeExecution(this.constructionType, player.id(), this.tile),
         );

--- a/src/core/execution/NukeExecution.ts
+++ b/src/core/execution/NukeExecution.ts
@@ -141,6 +141,14 @@ export class NukeExecution implements Execution {
             target.id(),
           );
           this.breakAlliances(this.tilesToDestroy());
+        } else if (this.type === UnitType.PlaneBomb) {
+          this.mg.displayIncomingUnit(
+            this.nuke.id(),
+            `${this.player.name()} - plane bomb inbound`,
+            MessageType.ERROR,
+            target.id(),
+          );
+          this.breakAlliances(this.tilesToDestroy());
         }
 
         // Record stats
@@ -150,11 +158,13 @@ export class NukeExecution implements Execution {
       }
 
       // after sending a nuke set the missilesilo on cooldown
-      const silo = this.player
-        .units(UnitType.MissileSilo)
-        .find((silo) => silo.tile() === spawn);
-      if (silo) {
-        silo.launch();
+      if (this.type !== UnitType.PlaneBomb) {
+        const silo = this.player
+          .units(UnitType.MissileSilo)
+          .find((silo) => silo.tile() === spawn);
+        if (silo) {
+          silo.launch();
+        }
       }
       return;
     }
@@ -231,7 +241,11 @@ export class NukeExecution implements Execution {
         unit.type() !== UnitType.AtomBomb &&
         unit.type() !== UnitType.HydrogenBomb &&
         unit.type() !== UnitType.MIRVWarhead &&
-        unit.type() !== UnitType.MIRV
+        unit.type() !== UnitType.MIRV &&
+        unit.type() !== UnitType.PlaneBomb &&
+        (this.nuke.type() !== UnitType.PlaneBomb ||
+          (unit.type() !== UnitType.WarPlane &&
+            unit.type() !== UnitType.TradePlane))
       ) {
         if (this.mg.euclideanDistSquared(this.dst, unit.tile()) < outer2) {
           unit.delete(true, this.player);

--- a/src/core/game/Game.ts
+++ b/src/core/game/Game.ts
@@ -140,6 +140,7 @@ export enum UnitType {
   Port = "Port",
   AtomBomb = "Atom Bomb",
   HydrogenBomb = "Hydrogen Bomb",
+  PlaneBomb = "Plane Bomb",
   TradeShip = "Trade Ship",
   TradePlane = "Trade Plane",
   WarPlane = "War Plane",
@@ -186,6 +187,10 @@ export interface UnitParamsMap {
     targetTile?: number;
   };
 
+  [UnitType.PlaneBomb]: {
+    targetTile?: number;
+  };
+
   [UnitType.TradeShip]: {
     targetUnit: Unit;
     lastSetSafeFromPirates?: number;
@@ -226,6 +231,7 @@ export type AllUnitParams = UnitParamsMap[keyof UnitParamsMap];
 export const nukeTypes = [
   UnitType.AtomBomb,
   UnitType.HydrogenBomb,
+  UnitType.PlaneBomb,
   UnitType.MIRVWarhead,
   UnitType.MIRV,
 ] as UnitType[];

--- a/src/core/game/PlayerImpl.ts
+++ b/src/core/game/PlayerImpl.ts
@@ -776,6 +776,8 @@ export class PlayerImpl implements Player {
       case UnitType.AtomBomb:
       case UnitType.HydrogenBomb:
         return this.nukeSpawn(targetTile);
+      case UnitType.PlaneBomb:
+        return this.planeBombSpawn(targetTile);
       case UnitType.MIRVWarhead:
         return targetTile;
       case UnitType.Port:
@@ -873,6 +875,18 @@ export class PlayerImpl implements Player {
       return false;
     }
     return spawns[0].tile();
+  }
+
+  planeBombSpawn(tile: TileRef): TileRef | false {
+    const planes = this.units(UnitType.WarPlane).sort(
+      (a, b) =>
+        this.mg.manhattanDist(a.tile(), tile) -
+        this.mg.manhattanDist(b.tile(), tile),
+    );
+    if (planes.length === 0) {
+      return false;
+    }
+    return planes[0].tile();
   }
 
   landBasedStructureSpawn(


### PR DESCRIPTION
## Summary
- add new `PlaneBomb` unit type for air-dropped nukes
- allow constructing plane bombs from the build menu
- plane bombs spawn from a warplane tile and are not intercepted by SAM
- plane bombs spare warplanes and trade planes from destruction
- localize plane bomb strings in English and French
- fix crash when plane bomb detonates
- load plane bombs with the atom bomb sprite

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68433caceea8832e9e66993cd2525a80