### PR TITLE
Fix plane bomb handling

### DIFF
--- a/src/core/execution/ConstructionExecution.ts
+++ b/src/core/execution/ConstructionExecution.ts
@@ -17,6 +17,7 @@ import { FactoryExecution } from "./FactoryExecution";
 import { MirvExecution } from "./MIRVExecution";
 import { MissileSiloExecution } from "./MissileSiloExecution";
 import { NukeExecution } from "./NukeExecution";
+import { PlaneBombExecution } from "./PlaneBombExecution";
 import { PortExecution } from "./PortExecution";
 import { SAMLauncherExecution } from "./SAMLauncherExecution";
 import { WarPlaneExecution } from "./WarPlaneExecution";
@@ -100,10 +101,12 @@ export class ConstructionExecution implements Execution {
     switch (this.constructionType) {
       case UnitType.AtomBomb:
       case UnitType.HydrogenBomb:
-      case UnitType.PlaneBomb:
         this.mg.addExecution(
           new NukeExecution(this.constructionType, player.id(), this.tile),
         );
+        break;
+      case UnitType.PlaneBomb:
+        this.mg.addExecution(new PlaneBombExecution(player.id(), this.tile));
         break;
       case UnitType.MIRV:
         this.mg.addExecution(new MirvExecution(player.id(), this.tile));

--- a/src/core/execution/NukeExecution.ts
+++ b/src/core/execution/NukeExecution.ts
@@ -237,6 +237,9 @@ export class NukeExecution implements Execution {
 
     const outer2 = magnitude.outer * magnitude.outer;
     for (const unit of this.mg.units()) {
+      if (unit === this.nuke) {
+        continue;
+      }
       if (
         unit.type() !== UnitType.AtomBomb &&
         unit.type() !== UnitType.HydrogenBomb &&

--- a/src/core/execution/PlaneBombExecution.ts
+++ b/src/core/execution/PlaneBombExecution.ts
@@ -1,0 +1,79 @@
+import {
+  Execution,
+  Game,
+  Player,
+  PlayerID,
+  Unit,
+  UnitType,
+} from "../game/Game";
+import { TileRef } from "../game/GameMap";
+import { NukeExecution } from "./NukeExecution";
+
+export class PlaneBombExecution implements Execution {
+  private mg: Game | null = null;
+  private player: Player | null = null;
+  private plane: Unit | null = null;
+  private active = true;
+  private bombDropped = false;
+
+  constructor(
+    private readonly playerID: PlayerID,
+    private readonly target: TileRef,
+  ) {}
+
+  init(mg: Game, ticks: number): void {
+    this.mg = mg;
+    if (!mg.hasPlayer(this.playerID)) {
+      console.warn(`PlaneBombExecution: player ${this.playerID} not found`);
+      this.active = false;
+      return;
+    }
+    this.player = mg.player(this.playerID);
+    const planes = this.player
+      .units(UnitType.WarPlane)
+      .sort(
+        (a, b) =>
+          mg.manhattanDist(a.tile(), this.target) -
+          mg.manhattanDist(b.tile(), this.target),
+      );
+    this.plane = planes[0] ?? null;
+    if (!this.plane) {
+      console.warn("PlaneBombExecution: no war plane available");
+      this.active = false;
+      return;
+    }
+
+    this.plane.setPatrolTile(this.target);
+    this.plane.setTargetTile(this.target);
+  }
+
+  tick(ticks: number): void {
+    if (!this.active || !this.mg || !this.player || !this.plane) {
+      return;
+    }
+    if (!this.plane.isActive()) {
+      this.active = false;
+      return;
+    }
+    if (!this.bombDropped && this.plane.tile() === this.target) {
+      this.mg.addExecution(
+        new NukeExecution(
+          UnitType.PlaneBomb,
+          this.player.id(),
+          this.target,
+          this.plane.tile(),
+        ),
+      );
+      this.bombDropped = true;
+      this.active = false;
+    }
+  }
+
+  isActive(): boolean {
+    return this.active;
+  }
+
+  activeDuringSpawnPhase(): boolean {
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary
- handle plane bombs with a dedicated execution
- move the warplane to the bombing tile before dropping
- ensure plane bomb detonates once the plane arrives

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6843572bedb0832e9b19886f2e8bcd42