### PR TITLE
Update factory gold and cost

### DIFF
--- a/src/core/configuration/DefaultConfig.ts
+++ b/src/core/configuration/DefaultConfig.ts
@@ -448,7 +448,15 @@ export class DefaultConfig implements Config {
           cost: (p: Player) =>
             p.type() === PlayerType.Human && this.infiniteGold()
               ? 0n
-              : 250_000n,
+              : (() => {
+                  const num = p.unitsIncludingConstruction(
+                    UnitType.Factory,
+                  ).length;
+                  if (num === 0) return 0n;
+                  if (num === 1) return 250_000n;
+                  if (num === 2) return 500_000n;
+                  return 1_000_000n;
+                })(),
           territoryBound: true,
           constructionDuration: this.instantBuild() ? 0 : 2 * 10,
         };

--- a/src/core/execution/FactoryExecution.ts
+++ b/src/core/execution/FactoryExecution.ts
@@ -16,9 +16,12 @@ export class FactoryExecution implements Execution {
   private factory: Unit | null = null;
   private active = true;
 
-  private goldPerTick: Gold = 100n; // 1000 gold per second at 10 ticks/sec
+  private goldPerTick: Gold = 500n; // 5000 gold per second at 10 ticks/sec
 
-  constructor(private ownerId: PlayerID, private tile: TileRef) {}
+  constructor(
+    private ownerId: PlayerID,
+    private tile: TileRef,
+  ) {}
 
   init(mg: Game, ticks: number): void {
     this.mg = mg;

--- a/tests/Factory.test.ts
+++ b/tests/Factory.test.ts
@@ -1,0 +1,46 @@
+import { SpawnExecution } from "../src/core/execution/SpawnExecution";
+import {
+  Game,
+  Player,
+  PlayerInfo,
+  PlayerType,
+  UnitType,
+} from "../src/core/game/Game";
+import { setup } from "./util/Setup";
+import { constructionExecution } from "./util/utils";
+
+let game: Game;
+let player: Player;
+
+beforeEach(async () => {
+  game = await setup("Plains", { instantBuild: true });
+  const info = new PlayerInfo(
+    "fr",
+    "factory dude",
+    PlayerType.Human,
+    null,
+    "p1",
+  );
+  game.addPlayer(info);
+  const spawnTile = game.ref(1, 1);
+  game.addExecution(new SpawnExecution(game.player(info.id).info(), spawnTile));
+  while (game.inSpawnPhase()) {
+    game.executeNextTick();
+  }
+  player = game.player(info.id);
+  player.addGold(5_000_000n);
+});
+
+test("factory cost scales with number owned", () => {
+  const unitInfo = game.config().unitInfo(UnitType.Factory);
+
+  expect(unitInfo.cost(player)).toBe(0n);
+  constructionExecution(game, player.id(), 1, 1, UnitType.Factory);
+  expect(unitInfo.cost(player)).toBe(250_000n);
+  constructionExecution(game, player.id(), 1, 1, UnitType.Factory);
+  expect(unitInfo.cost(player)).toBe(500_000n);
+  constructionExecution(game, player.id(), 1, 1, UnitType.Factory);
+  expect(unitInfo.cost(player)).toBe(1_000_000n);
+  constructionExecution(game, player.id(), 1, 1, UnitType.Factory);
+  expect(unitInfo.cost(player)).toBe(1_000_000n);
+});


### PR DESCRIPTION
## Summary
- bump factory gold generation rate from 1000 to 5000 per second
- scale factory build cost based on number of existing factories
- add test covering factory cost scaling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68444983a784832eabd6c2ef4c978712