### PR TITLE
Add warplane color change

### DIFF
--- a/src/client/graphics/SpriteLoader.ts
+++ b/src/client/graphics/SpriteLoader.ts
@@ -149,11 +149,41 @@ export const getColoredSprite = (
   }
 
   if (unit.type() === UnitType.WarPlane) {
+    const squareColor = theme.territoryColor(owner);
+    const planeColor = customTerritoryColor ?? colord("#a81e1e");
+    const planeKey = `${unit.type()}-${owner.id()}-${squareColor.toRgbString()}-${planeColor.toRgbString()}`;
+    if (coloredSpriteCache.has(planeKey)) {
+      return coloredSpriteCache.get(planeKey)!;
+    }
+
     const canvas = document.createElement("canvas");
     canvas.width = sprite.width;
     canvas.height = sprite.height;
     const ctx2 = canvas.getContext("2d")!;
     ctx2.drawImage(sprite, 0, 0);
+
+    const imgData = ctx2.getImageData(0, 0, canvas.width, canvas.height);
+    const data = imgData.data;
+    const squareRgb = squareColor.toRgb();
+    const bodyRgb = planeColor.toRgb();
+
+    for (let i = 0; i < data.length; i += 4) {
+      const r = data[i],
+        g = data[i + 1],
+        b = data[i + 2];
+      if (r === 130 && g === 130 && b === 130) {
+        data[i] = squareRgb.r;
+        data[i + 1] = squareRgb.g;
+        data[i + 2] = squareRgb.b;
+      } else if (r === 168 && g === 30 && b === 30) {
+        data[i] = bodyRgb.r;
+        data[i + 1] = bodyRgb.g;
+        data[i + 2] = bodyRgb.b;
+      }
+    }
+
+    ctx2.putImageData(imgData, 0, 0);
+    coloredSpriteCache.set(planeKey, canvas);
     return canvas;
   }
 

--- a/src/client/graphics/layers/UnitLayer.ts
+++ b/src/client/graphics/layers/UnitLayer.ts
@@ -335,8 +335,10 @@ export class UnitLayer implements Layer {
   }
 
   private handleWarPlaneEvent(unit: UnitView) {
-    if (unit.targetUnitId()) {
-      this.drawSprite(unit, colord({ r: 200, b: 0, g: 0 }));
+    const lastAttack = unit.lastAttackTick();
+    const highlight = lastAttack !== null && this.game.ticks() - lastAttack < 5;
+    if (highlight) {
+      this.drawSprite(unit, colord("#000000"));
     } else {
       this.drawSprite(unit);
     }

--- a/src/core/execution/WarPlaneExecution.ts
+++ b/src/core/execution/WarPlaneExecution.ts
@@ -103,6 +103,7 @@ export class WarPlaneExecution implements Execution {
           this.plane.targetUnit()!,
         ),
       );
+      this.plane.setLastAttackTick(this.mg.ticks());
       if (!this.plane.targetUnit()!.hasHealth()) {
         this.alreadySentShell.add(this.plane.targetUnit()!);
         this.plane.setTargetUnit(undefined);

--- a/src/core/game/Game.ts
+++ b/src/core/game/Game.ts
@@ -421,6 +421,10 @@ export interface Unit {
   // Warships
   setPatrolTile(tile: TileRef): void;
   patrolTile(): TileRef | undefined;
+
+  // Combat visuals
+  setLastAttackTick(tick: Tick): void;
+  lastAttackTick(): Tick | null;
 }
 
 export interface TerraNullius {

--- a/src/core/game/GameUpdates.ts
+++ b/src/core/game/GameUpdates.ts
@@ -81,6 +81,7 @@ export interface UnitUpdate {
   health?: number;
   constructionType?: UnitType;
   ticksLeftInCooldown?: Tick;
+  lastAttackTick?: Tick;
 }
 
 export interface AttackUpdate {

--- a/src/core/game/GameView.ts
+++ b/src/core/game/GameView.ts
@@ -118,6 +118,10 @@ export class UnitView {
     if (this.data.ticksLeftInCooldown === undefined) return false;
     return this.data.ticksLeftInCooldown > 0;
   }
+
+  lastAttackTick(): Tick | null {
+    return this.data.lastAttackTick ?? null;
+  }
 }
 
 export class PlayerView {

--- a/src/core/game/UnitImpl.ts
+++ b/src/core/game/UnitImpl.ts
@@ -27,6 +27,7 @@ export class UnitImpl implements Unit {
   private _lastOwner: PlayerImpl | null = null;
   private _troops: number;
   private _cooldownStartTick: Tick | null = null;
+  private _lastAttackTick: Tick | null = null;
   private _patrolTile: TileRef | undefined;
   constructor(
     private _type: UnitType,
@@ -107,6 +108,7 @@ export class UnitImpl implements Unit {
       targetUnitId: this._targetUnit?.id() ?? undefined,
       targetTile: this.targetTile() ?? undefined,
       ticksLeftInCooldown: this.ticksLeftInCooldown() ?? undefined,
+      lastAttackTick: this._lastAttackTick ?? undefined,
     };
   }
 
@@ -339,5 +341,14 @@ export class UnitImpl implements Unit {
       this.mg.ticks() - this._lastSetSafeFromPirates <
       this.mg.config().safeFromPiratesCooldownMax()
     );
+  }
+
+  setLastAttackTick(tick: Tick): void {
+    this._lastAttackTick = tick;
+    this.touch();
+  }
+
+  lastAttackTick(): Tick | null {
+    return this._lastAttackTick;
   }
 }


### PR DESCRIPTION
## Summary
- add lastAttackTick to unit interfaces and updates
- set lastAttackTick when warplane fires
- show player's color on warplane emblem
- display warplane in black briefly after attack

## Testing
- `npm test`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_684454f8d684832e89f4c3dfe1eb160b