### PR TITLE
Add warplane color change

### DIFF
--- a/src/client/graphics/layers/UnitLayer.ts
+++ b/src/client/graphics/layers/UnitLayer.ts
@@ -335,11 +335,10 @@ export class UnitLayer implements Layer {
   }
 
   private handleWarPlaneEvent(unit: UnitView) {
-    if (unit.targetUnitId()) {
-      this.drawSprite(unit, colord({ r: 200, b: 0, g: 0 }));
-    } else {
-      this.drawSprite(unit);
-    }
+    const lastAttack = unit.lastAttackTick();
+    const highlight = lastAttack !== null && this.game.ticks() - lastAttack < 5;
+    const squareColor = highlight ? colord("#ff0000") : colord("#00ff00");
+    this.drawSprite(unit, undefined, 0, squareColor);
   }
 
   private handleShellEvent(unit: UnitView) {
@@ -560,6 +559,7 @@ export class UnitLayer implements Layer {
     unit: UnitView,
     customTerritoryColor?: Colord,
     rotation: number = 0,
+    customSquareColor?: Colord,
   ) {
     if (!isSpriteReady(unit.type())) {
       return; // sprite still loading
@@ -602,6 +602,7 @@ export class UnitLayer implements Layer {
       this.theme,
       alternateViewColor ?? customTerritoryColor,
       alternateViewColor ?? undefined,
+      customSquareColor,
     );
 
     if (unit.isActive()) {

--- a/src/core/execution/WarPlaneExecution.ts
+++ b/src/core/execution/WarPlaneExecution.ts
@@ -103,6 +103,7 @@ export class WarPlaneExecution implements Execution {
           this.plane.targetUnit()!,
         ),
       );
+      this.plane.setLastAttackTick(this.mg.ticks());
       if (!this.plane.targetUnit()!.hasHealth()) {
         this.alreadySentShell.add(this.plane.targetUnit()!);
         this.plane.setTargetUnit(undefined);

--- a/src/core/game/Game.ts
+++ b/src/core/game/Game.ts
@@ -421,6 +421,10 @@ export interface Unit {
   // Warships
   setPatrolTile(tile: TileRef): void;
   patrolTile(): TileRef | undefined;
+
+  // Combat visuals
+  setLastAttackTick(tick: Tick): void;
+  lastAttackTick(): Tick | null;
 }
 
 export interface TerraNullius {

--- a/src/core/game/GameUpdates.ts
+++ b/src/core/game/GameUpdates.ts
@@ -81,6 +81,7 @@ export interface UnitUpdate {
   health?: number;
   constructionType?: UnitType;
   ticksLeftInCooldown?: Tick;
+  lastAttackTick?: Tick;
 }
 
 export interface AttackUpdate {

--- a/src/core/game/GameView.ts
+++ b/src/core/game/GameView.ts
@@ -118,6 +118,10 @@ export class UnitView {
     if (this.data.ticksLeftInCooldown === undefined) return false;
     return this.data.ticksLeftInCooldown > 0;
   }
+
+  lastAttackTick(): Tick | null {
+    return this.data.lastAttackTick ?? null;
+  }
 }
 
 export class PlayerView {

--- a/src/core/game/UnitImpl.ts
+++ b/src/core/game/UnitImpl.ts
@@ -27,6 +27,7 @@ export class UnitImpl implements Unit {
   private _lastOwner: PlayerImpl | null = null;
   private _troops: number;
   private _cooldownStartTick: Tick | null = null;
+  private _lastAttackTick: Tick | null = null;
   private _patrolTile: TileRef | undefined;
   constructor(
     private _type: UnitType,
@@ -107,6 +108,7 @@ export class UnitImpl implements Unit {
       targetUnitId: this._targetUnit?.id() ?? undefined,
       targetTile: this.targetTile() ?? undefined,
       ticksLeftInCooldown: this.ticksLeftInCooldown() ?? undefined,
+      lastAttackTick: this._lastAttackTick ?? undefined,
     };
   }
 
@@ -339,5 +341,14 @@ export class UnitImpl implements Unit {
       this.mg.ticks() - this._lastSetSafeFromPirates <
       this.mg.config().safeFromPiratesCooldownMax()
     );
+  }
+
+  setLastAttackTick(tick: Tick): void {
+    this._lastAttackTick = tick;
+    this.touch();
+  }
+
+  lastAttackTick(): Tick | null {
+    return this._lastAttackTick;
   }
 }


### PR DESCRIPTION
## Summary
- add square color parameter for warplane sprites
- paint warplane using player color while the square stays green
- flash the square red briefly when the warplane fires

## Testing
- `npm test`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_684454f8d684832e89f4c3dfe1eb160b