### PR TITLE
Highlight warplane when bombing

### DIFF
--- a/src/client/graphics/layers/UnitLayer.ts
+++ b/src/client/graphics/layers/UnitLayer.ts
@@ -335,8 +335,8 @@ export class UnitLayer implements Layer {
   }
 
   private handleWarPlaneEvent(unit: UnitView) {
-    const lastAttack = unit.lastAttackTick();
-    const highlight = lastAttack !== null && this.game.ticks() - lastAttack < 5;
+    const lastBomb = unit.lastBombTick();
+    const highlight = lastBomb !== null && this.game.ticks() - lastBomb < 5;
     const squareColor = highlight ? colord("#ff0000") : colord("#00ff00");
     this.drawSprite(unit, undefined, 0, squareColor);
   }

--- a/src/core/execution/PlaneBombExecution.ts
+++ b/src/core/execution/PlaneBombExecution.ts
@@ -68,6 +68,7 @@ export class PlaneBombExecution implements Execution {
           this.plane.tile(),
         ),
       );
+      this.plane.setLastBombTick(this.mg.ticks());
       this.bombDropped = true;
       if (this.prevPatrolTile !== undefined) {
         this.plane.setPatrolTile(this.prevPatrolTile);

--- a/src/core/game/Game.ts
+++ b/src/core/game/Game.ts
@@ -425,6 +425,8 @@ export interface Unit {
   // Combat visuals
   setLastAttackTick(tick: Tick): void;
   lastAttackTick(): Tick | null;
+  setLastBombTick(tick: Tick): void;
+  lastBombTick(): Tick | null;
 }
 
 export interface TerraNullius {

--- a/src/core/game/GameUpdates.ts
+++ b/src/core/game/GameUpdates.ts
@@ -82,6 +82,7 @@ export interface UnitUpdate {
   constructionType?: UnitType;
   ticksLeftInCooldown?: Tick;
   lastAttackTick?: Tick;
+  lastBombTick?: Tick;
 }
 
 export interface AttackUpdate {

--- a/src/core/game/GameView.ts
+++ b/src/core/game/GameView.ts
@@ -122,6 +122,10 @@ export class UnitView {
   lastAttackTick(): Tick | null {
     return this.data.lastAttackTick ?? null;
   }
+
+  lastBombTick(): Tick | null {
+    return this.data.lastBombTick ?? null;
+  }
 }
 
 export class PlayerView {

--- a/src/core/game/UnitImpl.ts
+++ b/src/core/game/UnitImpl.ts
@@ -28,6 +28,7 @@ export class UnitImpl implements Unit {
   private _troops: number;
   private _cooldownStartTick: Tick | null = null;
   private _lastAttackTick: Tick | null = null;
+  private _lastBombTick: Tick | null = null;
   private _patrolTile: TileRef | undefined;
   constructor(
     private _type: UnitType,
@@ -109,6 +110,7 @@ export class UnitImpl implements Unit {
       targetTile: this.targetTile() ?? undefined,
       ticksLeftInCooldown: this.ticksLeftInCooldown() ?? undefined,
       lastAttackTick: this._lastAttackTick ?? undefined,
+      lastBombTick: this._lastBombTick ?? undefined,
     };
   }
 
@@ -350,5 +352,14 @@ export class UnitImpl implements Unit {
 
   lastAttackTick(): Tick | null {
     return this._lastAttackTick;
+  }
+
+  setLastBombTick(tick: Tick): void {
+    this._lastBombTick = tick;
+    this.touch();
+  }
+
+  lastBombTick(): Tick | null {
+    return this._lastBombTick;
   }
 }


### PR DESCRIPTION
## Summary
- add `lastBombTick` to `Unit` implementation and interfaces
- send `lastBombTick` in unit updates and expose it to game view
- track plane bomb timestamp when dropping bombs
- highlight warplane sprite only on recent bombing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684463dcedf4832ebe9aef447290b493