### PR TITLE
Plane bomb highlight on selection

### DIFF
--- a/src/client/graphics/layers/UnitLayer.ts
+++ b/src/client/graphics/layers/UnitLayer.ts
@@ -336,7 +336,8 @@ export class UnitLayer implements Layer {
 
   private handleWarPlaneEvent(unit: UnitView) {
     const lastBomb = unit.lastBombTick();
-    const highlight = lastBomb !== null && this.game.ticks() - lastBomb < 5;
+    const cd = this.game.config().planeBombCooldown();
+    const highlight = lastBomb !== null && this.game.ticks() - lastBomb < cd;
     const squareColor = highlight ? colord("#ff0000") : colord("#00ff00");
     this.drawSprite(unit, undefined, 0, squareColor);
   }

--- a/src/core/configuration/Config.ts
+++ b/src/core/configuration/Config.ts
@@ -129,6 +129,7 @@ export interface Config {
   defensePostRange(): number;
   SAMCooldown(): number;
   SiloCooldown(): number;
+  planeBombCooldown(): number;
   defensePostDefenseBonus(): number;
   falloutDefenseModifier(percentOfFallout: number): number;
   difficultyModifier(difficulty: Difficulty): number;

--- a/src/core/configuration/DefaultConfig.ts
+++ b/src/core/configuration/DefaultConfig.ts
@@ -240,6 +240,9 @@ export class DefaultConfig implements Config {
   SiloCooldown(): number {
     return 75;
   }
+  planeBombCooldown(): number {
+    return 70;
+  }
 
   defensePostRange(): number {
     return 30;

--- a/src/core/execution/PlaneBombExecution.ts
+++ b/src/core/execution/PlaneBombExecution.ts
@@ -30,8 +30,14 @@ export class PlaneBombExecution implements Execution {
       return;
     }
     this.player = mg.player(this.playerID);
+    const cooldown = mg.config().planeBombCooldown();
     const planes = this.player
       .units(UnitType.WarPlane)
+      .filter((p) => {
+        const last = p.lastBombTick();
+        if (p.isInCooldown()) return false;
+        return last === null || mg.ticks() - last >= cooldown;
+      })
       .sort(
         (a, b) =>
           mg.manhattanDist(a.tile(), this.target) -
@@ -49,6 +55,8 @@ export class PlaneBombExecution implements Execution {
     // Move directly towards the target tile
     this.plane.setPatrolTile(this.target);
     this.plane.setTargetTile(this.target);
+    // Mark the plane as preparing to drop a bomb
+    this.plane.setLastBombTick(this.mg.ticks());
   }
 
   tick(ticks: number): void {
@@ -58,6 +66,10 @@ export class PlaneBombExecution implements Execution {
     if (!this.plane.isActive()) {
       this.active = false;
       return;
+    }
+    if (!this.bombDropped) {
+      // Continually update so the client knows the plane is on a bombing run
+      this.plane.setLastBombTick(this.mg.ticks());
     }
     if (!this.bombDropped && this.plane.tile() === this.target) {
       this.mg.addExecution(
@@ -69,6 +81,7 @@ export class PlaneBombExecution implements Execution {
         ),
       );
       this.plane.setLastBombTick(this.mg.ticks());
+      this.plane.launch();
       this.bombDropped = true;
       if (this.prevPatrolTile !== undefined) {
         this.plane.setPatrolTile(this.prevPatrolTile);

--- a/src/core/execution/WarPlaneExecution.ts
+++ b/src/core/execution/WarPlaneExecution.ts
@@ -58,15 +58,17 @@ export class WarPlaneExecution implements Execution {
     if (hasAirport) {
       this.plane.modifyHealth(1);
     }
-
-    this.plane.setTargetUnit(this.findTargetUnit());
+    if (this.plane.isInCooldown()) {
+      this.plane.setTargetUnit(undefined);
+    } else {
+      this.plane.setTargetUnit(this.findTargetUnit());
+      if (this.plane.targetUnit() !== undefined) {
+        this.shootTarget();
+        return;
+      }
+    }
 
     this.patrol();
-
-    if (this.plane.targetUnit() !== undefined) {
-      this.shootTarget();
-      return;
-    }
   }
 
   private findTargetUnit(): Unit | undefined {

--- a/src/core/game/UnitImpl.ts
+++ b/src/core/game/UnitImpl.ts
@@ -286,6 +286,8 @@ export class UnitImpl implements Unit {
       cooldownDuration = this.mg.config().SAMCooldown();
     } else if (this.type() === UnitType.MissileSilo) {
       cooldownDuration = this.mg.config().SiloCooldown();
+    } else if (this.type() === UnitType.WarPlane) {
+      cooldownDuration = this.mg.config().planeBombCooldown();
     } else {
       return undefined;
     }


### PR DESCRIPTION
## Summary
- highlight warplane when it's on a bombing run
- implement 7-second cooldown for warplanes after bombing runs
- ensure planes in cooldown can't attack or be chosen for bombing

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68446776db80832e833711afa2eee7e7