### PR TITLE
Increase AI aggression with air and hydrogen bombs

### DIFF
--- a/src/core/configuration/DefaultConfig.ts
+++ b/src/core/configuration/DefaultConfig.ts
@@ -354,7 +354,7 @@ export class DefaultConfig implements Config {
           cost: (p: Player) =>
             p.type() === PlayerType.Human && this.infiniteGold()
               ? 0n
-              : 5_000_000n,
+              : 2_500_000n,
           territoryBound: false,
         };
       case UnitType.PlaneBomb:


### PR DESCRIPTION
## Summary
- adjust FakeHuman bot to act and attack more frequently
- remove hydrogen bomb safeguards and increase usage
- loosen nuke target cooldown
- spawn more planes for stronger nations
- lower hydrogen bomb cost

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6845abb2244c832ebe528ac4b1557427