### PR TITLE
Fix Red Air targeting

### DIFF
--- a/src/core/execution/RedAirExecution.ts
+++ b/src/core/execution/RedAirExecution.ts
@@ -90,9 +90,13 @@ export class RedAirExecution implements Execution {
       UnitType.Airport,
       UnitType.SAMLauncher,
     ];
-    const enemies = this.mg
-      .players()
-      .filter((p) => p !== this.player && !this.player!.isFriendly(p));
+    const targeted = this.player.targets();
+    const enemies =
+      targeted.length > 0
+        ? targeted
+        : this.mg
+            .players()
+            .filter((p) => p !== this.player && !this.player!.isFriendly(p));
     const candidates: { tile: TileRef; score: number }[] = [];
     const radius = this.mg.config().nukeMagnitudes(UnitType.AtomBomb).outer;
     for (const enemy of enemies) {


### PR DESCRIPTION
## Summary
- ensure Red Air planes attack targeted players

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6846db5f21d4832e9b8f2ed1362ed7ce