### PR TITLE
Fix Red Air targeting

### DIFF
--- a/src/client/Transport.ts
+++ b/src/client/Transport.ts
@@ -162,7 +162,7 @@ export class MoveWarPlaneIntentEvent implements GameEvent {
 }
 
 export class SendRedAirIntentEvent implements GameEvent {
-  constructor() {}
+  constructor(public readonly targetID: string) {}
 }
 
 export class Transport {
@@ -239,8 +239,8 @@ export class Transport {
     this.eventBus.on(MoveWarPlaneIntentEvent, (e) => {
       this.onMoveWarPlaneEvent(e);
     });
-    this.eventBus.on(SendRedAirIntentEvent, () => {
-      this.onSendRedAirIntent();
+    this.eventBus.on(SendRedAirIntentEvent, (e) => {
+      this.onSendRedAirIntent(e);
     });
   }
 
@@ -611,10 +611,11 @@ export class Transport {
     });
   }
 
-  private onSendRedAirIntent() {
+  private onSendRedAirIntent(event: SendRedAirIntentEvent) {
     this.sendIntent({
       type: "red_air",
       clientID: this.lobbyConfig.clientID,
+      targetID: event.targetID,
     });
   }
 

--- a/src/client/graphics/layers/BuildMenu.ts
+++ b/src/client/graphics/layers/BuildMenu.ts
@@ -17,7 +17,7 @@ import { translateText } from "../../../client/Utils";
 import { EventBus } from "../../../core/EventBus";
 import { Cell, Gold, PlayerActions, UnitType } from "../../../core/game/Game";
 import { TileRef } from "../../../core/game/GameMap";
-import { GameView } from "../../../core/game/GameView";
+import { GameView, PlayerView } from "../../../core/game/GameView";
 import { BuildUnitIntentEvent, SendRedAirIntentEvent } from "../../Transport";
 import { renderNumber } from "../../Utils";
 import { Layer } from "./Layer";
@@ -357,7 +357,9 @@ export class BuildMenu extends LitElement implements Layer {
       const player = this.game?.myPlayer();
       if (!player || this.playerActions === null) return false;
       const owner = this.game.owner(this.clickedTile);
-      if (!owner.isPlayer() || owner === player || player.isOnSameTeam(owner)) {
+      if (!owner.isPlayer()) return false;
+      const ownerPlayer = owner as PlayerView;
+      if (ownerPlayer === player || player.isOnSameTeam(ownerPlayer)) {
         return false;
       }
       const planes = this.availablePlanes();
@@ -405,7 +407,11 @@ export class BuildMenu extends LitElement implements Layer {
 
   public onBuildSelected = (item: BuildItemDisplay) => {
     if (item.action === "red_air") {
-      this.eventBus.emit(new SendRedAirIntentEvent());
+      const owner = this.game.owner(this.clickedTile);
+      if (owner.isPlayer()) {
+        const ownerPlayer = owner as PlayerView;
+        this.eventBus.emit(new SendRedAirIntentEvent(ownerPlayer.id()));
+      }
     } else if (item.unitType !== undefined) {
       this.eventBus.emit(
         new BuildUnitIntentEvent(

--- a/src/core/Schemas.ts
+++ b/src/core/Schemas.ts
@@ -290,6 +290,7 @@ export const MoveWarPlaneIntentSchema = BaseIntentSchema.extend({
 
 export const RedAirIntentSchema = BaseIntentSchema.extend({
   type: z.literal("red_air"),
+  targetID: ID,
 });
 
 export const QuickChatKeySchema = z.enum(

--- a/src/core/execution/ExecutionManager.ts
+++ b/src/core/execution/ExecutionManager.ts
@@ -112,7 +112,7 @@ export class Executor {
       case "embargo":
         return new EmbargoExecution(player, intent.targetID, intent.action);
       case "red_air":
-        return new RedAirExecution(playerID);
+        return new RedAirExecution(playerID, intent.targetID);
       case "build_unit":
         return new ConstructionExecution(
           playerID,

--- a/src/core/execution/RedAirExecution.ts
+++ b/src/core/execution/RedAirExecution.ts
@@ -23,7 +23,10 @@ export class RedAirExecution implements Execution {
   private assignments: Assignment[] = [];
   private active = true;
 
-  constructor(private readonly playerID: PlayerID) {}
+  constructor(
+    private readonly playerID: PlayerID,
+    private readonly targetID: PlayerID,
+  ) {}
 
   init(mg: Game, ticks: number): void {
     this.mg = mg;
@@ -52,7 +55,15 @@ export class RedAirExecution implements Execution {
     }
     this.player.removeGold(cost);
 
-    const targets = this.chooseTargets(planes.length);
+    const targetPlayer = mg.hasPlayer(this.targetID)
+      ? mg.player(this.targetID)
+      : null;
+    if (!targetPlayer || targetPlayer === this.player) {
+      this.active = false;
+      return;
+    }
+
+    const targets = this.chooseTargets(planes.length, targetPlayer);
     if (targets.length === 0) {
       this.active = false;
       return;
@@ -79,7 +90,7 @@ export class RedAirExecution implements Execution {
     });
   }
 
-  private chooseTargets(num: number): TileRef[] {
+  private chooseTargets(num: number, enemy: Player): TileRef[] {
     if (!this.mg || !this.player) return [];
     const buildingTypes = [
       UnitType.City,
@@ -90,13 +101,7 @@ export class RedAirExecution implements Execution {
       UnitType.Airport,
       UnitType.SAMLauncher,
     ];
-    const targeted = this.player.targets();
-    const enemies =
-      targeted.length > 0
-        ? targeted
-        : this.mg
-            .players()
-            .filter((p) => p !== this.player && !this.player!.isFriendly(p));
+    const enemies = [enemy];
     const candidates: { tile: TileRef; score: number }[] = [];
     const radius = this.mg.config().nukeMagnitudes(UnitType.AtomBomb).outer;
     for (const enemy of enemies) {


### PR DESCRIPTION
## Summary
- include target player in Red Air command
- send selected player's id from build menu
- route player id in Transport
- update execution manager to create RedAirExecution with target
- restrict RedAirExecution to bombing the selected player

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6846df11ea10832e8f41530f2aac2640